### PR TITLE
Release TSLocationManager 4.0.19

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "TSLocationManager",
-            url: "https://github.com/transistorsoft/native-background-geolocation/releases/download/4.0.19--create-branch/TSLocationManager.xcframework.zip",
-            checksum: "c751d8a0ef1eaf3e9f5df43c95540403510ba7b74110ccb361642395876e5844"
+            url: "https://github.com/transistorsoft/native-background-geolocation/releases/download/4.0.19/TSLocationManager.xcframework.zip",
+            checksum: "ff266d7c15c01516bc138640cc6b95534565215bb8648c0ad0c14cb5adcefa9c"
         ),
 
         // Wrapper Swift target that reexports the binary + TSBackgroundFetch

--- a/TSLocationManager.podspec
+++ b/TSLocationManager.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.author       = { 'Transistor Software' => 'info@transistorsoft.com' }
 
   # Binary distribution
-  s.source       = { :http => 'https://github.com/transistorsoft/native-background-geolocation/releases/download/4.0.19--create-branch/TSLocationManager.xcframework.zip' }
+  s.source       = { :http => 'https://github.com/transistorsoft/native-background-geolocation/releases/download/4.0.19/TSLocationManager.xcframework.zip' }
   s.vendored_frameworks   = 'TSLocationManager.xcframework'
   s.static_framework      = true
 


### PR DESCRIPTION
• Guard against posibility of creating `CLLocationManager` instances on background threads.  Can happen if getCurrentPosition called before ready.
• LocationFilter enabled by default: v5 introduces an on-device geolocation.filter layer (Kalman + kinematic/outlier logic) which can change which samples are delivered to onLocation and how distance deltas are smoothed/adjusted.
• Adaptive default for non-high accuracy: When geolocation.desiredAccuracy is not High/Navigation and the app has not explicitly configured geolocation.filter, the default geolocation.filter.policy now auto-relaxes to PassThrough to avoid overly aggressive rejection on low/medium accuracy profiles.
• Preserve v4 behavior: Set geolocation.filter.policy = PassThrough (and optionally disable Kalman / thresholds) to retain pre-v5 “raw” location behavior.